### PR TITLE
Use current module namespace URI

### DIFF
--- a/src/test/resources/conf.xml
+++ b/src/test/resources/conf.xml
@@ -746,7 +746,7 @@
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>
-            <module uri="https://exist-db.org/commons-text/lib" class="org.exist.xquery.functions.commons.text.CommonsTextModule"/>
+            <module uri="http://exist-db.org/xquery/commons-text" class="org.exist.xquery.functions.commons.text.CommonsTextModule"/>
         </builtin-modules>
     </xquery>
 


### PR DESCRIPTION
I caught one lingering reference to the older module namespace URI